### PR TITLE
Updated the make file

### DIFF
--- a/dm_collector_c/Makefile
+++ b/dm_collector_c/Makefile
@@ -1,11 +1,13 @@
 CXX = g++
-CXXFLAGS = -I/usr/include/python2.7 -lpython2.7
+CXXFLAGS = -I/usr/include/python2.7   
+LDFLAGS = -L/usr/lib/python2.7 -lpython
 
-dm_collector_c: dm_collector_c.o utils.o log_packet.o log_config.o hdlc.o export_manager.o
+src = $(wildcard *.cpp)
+obj = $(src:.cpp=.o)
 
-dm_collector_c.o: consts.h hdlc.h log_config.h log_packet.h export_manager.h
-export_manager.o: consts.h export_manager.h hdlc.h log_packet.h log_packet_helper.h
-hdlc.o: hdlc.h
-log_config.o: consts.h log_config.h
-log_packet.o: consts.h log_packet.h
-utils.o: utils.h
+dm_collector_c: $(obj)
+	$(CXX) -shared $(LDFLAGS) $^ -o $@  
+
+.NOTHIN: clean
+clean:
+	rm -f $(obj) dm_collector_c


### PR DESCRIPTION
This make file assumes that your Python libraries can be found in /usr/include/python2.7 and /usr/lib/python
To find the paths for your system use: 
$locate Python.h
$locate py_compile.pyo